### PR TITLE
Allow adding files by buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ import (
 
 Create a new tgz object:
 ```
-err, tgz := tgz.New("./fixtures/bar.tar.gz")
+tgz, err := tgz.New("./fixtures/bar.tar.gz")
 if err != nil {
     t.Fatal(err)
 }
@@ -20,7 +20,16 @@ if err != nil {
 Add a file by content:
 ```
 //First argument is the content in a byte array, second argument is where in the tgz it should be stored
-err = tgz.AddFileByContent([]byte("sdfsdfsdfs\n"), "test.txt")
+err = tgz.AddFileByContent([]byte("sdfsdfsdfs\n"), "file.txt")
+if err != nil {
+    t.Fatal(err)
+}
+```
+
+Or add a file from a populated buffer:
+```
+//First argument is the content in a byte buffer, second argument is where in the tgz it should be stored
+err = tgz.AddFileByBuffer(&byteBuffer, "file.txt")
 if err != nil {
     t.Fatal(err)
 }
@@ -37,7 +46,7 @@ if err != nil {
 
 Commit the changes to the tar.gz file:
 ```
-tgz.Finish()
+tgz.Close()
 ```
 
 ## Contributing

--- a/tgz.go
+++ b/tgz.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-type Tgz struct {
+type Archive struct {
 	Path      string
 	tgzFile   *os.File
 	tarWriter *tar.Writer
@@ -19,8 +19,8 @@ type Tgz struct {
 	finished  bool
 }
 
-func New(path string) (*Tgz, error) {
-	tgz := Tgz{Path: path}
+func New(path string) (*Archive, error) {
+	tgz := Archive{Path: path}
 	var err error
 	tgz.tgzFile, err = tgz.getTarFile()
 	if err != nil {
@@ -34,11 +34,11 @@ func New(path string) (*Tgz, error) {
 	return &tgz, nil
 }
 
-func (tgz *Tgz) AddFileByBuffer(b *bytes.Buffer, dest string) error {
+func (tgz *Archive) AddFileByBuffer(b *bytes.Buffer, dest string) error {
 	return tgz.AddFileByContent(b.Bytes(), dest)
 }
 
-func (tgz *Tgz) AddFileByPath(srcFile string, dest string) error {
+func (tgz *Archive) AddFileByPath(srcFile string, dest string) error {
 	if src, err := ioutil.ReadFile(srcFile); err == nil {
 		return tgz.AddFileByContent(src, dest)
 	} else {
@@ -46,7 +46,7 @@ func (tgz *Tgz) AddFileByPath(srcFile string, dest string) error {
 	}
 }
 
-func (tgz *Tgz) AddFileByContent(src []byte, dest string) error {
+func (tgz *Archive) AddFileByContent(src []byte, dest string) error {
 	if tgz.finished == true {
 		return errors.New("Gzip file has already been finished, cannot add more files")
 	}
@@ -71,14 +71,14 @@ func (tgz *Tgz) AddFileByContent(src []byte, dest string) error {
 	return nil
 }
 
-func (tgz *Tgz) Close() {
+func (tgz *Archive) Close() {
 	tgz.finished = true
 	tgz.tarWriter.Close()
 	tgz.gzWriter.Close()
 	tgz.tgzFile.Close()
 }
 
-func (tgz *Tgz) getTarFile() (*os.File, error) {
+func (tgz *Archive) getTarFile() (*os.File, error) {
 	var (
 		f   *os.File
 		err error

--- a/tgz.go
+++ b/tgz.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"errors"
 	"io"
 	"io/ioutil"
 	"os"
@@ -16,7 +15,6 @@ type Archive struct {
 	tgzFile   *os.File
 	tarWriter *tar.Writer
 	gzWriter  *gzip.Writer
-	finished  bool
 }
 
 func New(path string) (*Archive, error) {
@@ -29,7 +27,6 @@ func New(path string) (*Archive, error) {
 
 	tgz.gzWriter = gzip.NewWriter(tgz.tgzFile)
 	tgz.tarWriter = tar.NewWriter(tgz.gzWriter)
-	tgz.finished = false
 
 	return &tgz, nil
 }
@@ -47,9 +44,6 @@ func (tgz *Archive) AddFileByPath(srcFile string, dest string) error {
 }
 
 func (tgz *Archive) AddFileByContent(src []byte, dest string) error {
-	if tgz.finished == true {
-		return errors.New("Gzip file has already been finished, cannot add more files")
-	}
 	var (
 		err error
 	)
@@ -72,7 +66,6 @@ func (tgz *Archive) AddFileByContent(src []byte, dest string) error {
 }
 
 func (tgz *Archive) Close() {
-	tgz.finished = true
 	tgz.tarWriter.Close()
 	tgz.gzWriter.Close()
 	tgz.tgzFile.Close()

--- a/tgz_test.go
+++ b/tgz_test.go
@@ -353,53 +353,6 @@ func TestAddingFilesInSubdirs(t *testing.T) {
 	}
 }
 
-func TestWritingToAFinishedTgz(t *testing.T) {
-	tarFile := "./fixtures/filesInSubdirs.tar.gz"
-	tgz, err := New(tarFile)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.Remove(tgz.Path)
-	files := map[string]string{
-		"files/test1.txt":       "sdfsdfsdfs\n",
-		"files/test2.txt":       "sdfsdfsdfs\n",
-		"files/test3.txt":       "sdfsdfsdfs\n",
-		"files/test4.txt":       "sdfsdfsdfs\n",
-		"other_files/test1.txt": "sdfsdfsdfs\n",
-		"other_files/test2.txt": "sdfsdfsdfs\n",
-		"other_files/test3.txt": "sdfsdfsdfs\n",
-		"other_files/test4.txt": "sdfsdfsdfs\n",
-	}
-
-	for dest, content := range files {
-		err = tgz.AddFileByContent([]byte(content), dest)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-	tgz.Close()
-
-	tar, _ := os.Open(tgz.Path)
-	tarStats, _ := tar.Stat()
-	if tarStats.Size() == 0 {
-		t.Fatalf("tar file should be > 0 bytes, but is %d bytes", tarStats.Size())
-	}
-	if tarStats.Size() > 2048 {
-		t.Fatalf("tar is much larger than expected, should be < 2048 but is %d byes", tarStats.Size())
-	}
-
-	err = tgz.AddFileByContent([]byte("sdfsdfsdfs\n"), "test.txt")
-	if err.Error() != "Gzip file has already been finished, cannot add more files" {
-		t.Fatal("tgz should not allow more files to be added once finish has been called")
-	}
-	err = tgz.AddFileByPath("./fixtures/test.txt", "test.txt")
-	if err.Error() != "Gzip file has already been finished, cannot add more files" {
-		t.Fatal("tgz should not allow more files to be added once finish has been called")
-	}
-}
-
 func TestWritingToExistingTar(t *testing.T) {
 	tarFile := "./fixtures/rewriteTo.tar.gz"
 	tgz, err := New(tarFile)

--- a/tgz_test.go
+++ b/tgz_test.go
@@ -6,10 +6,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"bytes"
 )
 
 func TestNewTgz(t *testing.T) {
-	err, tgz := New("./fixtures/bar.tar.gz")
+	tgz, err := New("./fixtures/bar.tar.gz")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -22,7 +23,7 @@ func TestNewTgz(t *testing.T) {
 
 func TestAddingAFileByContent(t *testing.T) {
 	tarFile := "./fixtures/oneFileByContent.tar.gz"
-	err, tgz := New(tarFile)
+	tgz, err := New(tarFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +34,7 @@ func TestAddingAFileByContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tgz.Finish()
+	tgz.Close()
 
 	tar, _ := os.Open(tgz.Path)
 	tarStats, _ := tar.Stat()
@@ -45,7 +46,7 @@ func TestAddingAFileByContent(t *testing.T) {
 	}
 	tar.Close()
 
-	err, files := decompressAndListFiles(tgz.Path)
+	files, err := decompressAndListFiles(tgz.Path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +58,7 @@ func TestAddingAFileByContent(t *testing.T) {
 
 func TestAddingTwoFilesByContent(t *testing.T) {
 	tarFile := "./fixtures/twoFilesByContent.tar.gz"
-	err, tgz := New(tarFile)
+	tgz, err := New(tarFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +73,7 @@ func TestAddingTwoFilesByContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tgz.Finish()
+	tgz.Close()
 
 	tar, _ := os.Open(tgz.Path)
 	tarStats, _ := tar.Stat()
@@ -84,7 +85,7 @@ func TestAddingTwoFilesByContent(t *testing.T) {
 	}
 	tar.Close()
 
-	err, files := decompressAndListFiles(tgz.Path)
+	files, err := decompressAndListFiles(tgz.Path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +99,7 @@ func TestAddingTwoFilesByContent(t *testing.T) {
 
 func TestAddingAFileByPath(t *testing.T) {
 	tarFile := "./fixtures/oneFileByPath.tar.gz"
-	err, tgz := New(tarFile)
+	tgz, err := New(tarFile)
 
 	if err != nil {
 		t.Fatal(err)
@@ -111,7 +112,7 @@ func TestAddingAFileByPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tgz.Finish()
+	tgz.Close()
 
 	tar, _ := os.Open(tgz.Path)
 	tarStats, _ := tar.Stat()
@@ -123,7 +124,7 @@ func TestAddingAFileByPath(t *testing.T) {
 	}
 	tar.Close()
 
-	err, files := decompressAndListFiles(tgz.Path)
+	files, err := decompressAndListFiles(tgz.Path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,9 +133,94 @@ func TestAddingAFileByPath(t *testing.T) {
 	}
 }
 
+func TestAddingAFileByBuffer(t *testing.T) {
+	tarFile := "./fixtures/oneFileByBuffer.tar.gz"
+	tgz, err := New(tarFile)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Remove(tgz.Path)
+
+	b := &bytes.Buffer{}
+	b.Write([]byte("test\n"))
+	b.Write([]byte("test 2\n"))
+
+	err = tgz.AddFileByBuffer(b, "test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tgz.Close()
+
+	tar, _ := os.Open(tgz.Path)
+	tarStats, _ := tar.Stat()
+	if tarStats.Size() == 0 {
+		t.Fatalf("tar file should be > 0 bytes, but is %d bytes", tarStats.Size())
+	}
+	if tarStats.Size() > 2048 {
+		t.Fatalf("tar is much larger than expected, should be < 2048 but is %d byes", tarStats.Size())
+	}
+	tar.Close()
+
+	files, err := decompressAndListFiles(tgz.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := files["test.txt"]; !ok {
+		t.Fatal("Expected tgz to contain test.txt but it didnt")
+	}
+}
+
+
+func TestAddingTwoFilesByBuffer(t *testing.T) {
+	tarFile := "./fixtures/twoFilesByBuffer.tar.gz"
+	tgz, err := New(tarFile)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Remove(tgz.Path)
+
+	b := &bytes.Buffer{}
+	b.Write([]byte("test\n"))
+	b.Write([]byte("test 2\n"))
+
+	err = tgz.AddFileByBuffer(b, "test.txt")
+	err = tgz.AddFileByBuffer(b, "test2.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tgz.Close()
+
+	tar, _ := os.Open(tgz.Path)
+	tarStats, _ := tar.Stat()
+	if tarStats.Size() == 0 {
+		t.Fatalf("tar file should be > 0 bytes, but is %d bytes", tarStats.Size())
+	}
+	if tarStats.Size() > 2048 {
+		t.Fatalf("tar is much larger than expected, should be < 2048 but is %d byes", tarStats.Size())
+	}
+	tar.Close()
+
+	files, err := decompressAndListFiles(tgz.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := files["test.txt"]; !ok {
+		t.Fatal("Expected tgz to contain test.txt but it didnt")
+	}
+	if _, ok := files["test2.txt"]; !ok {
+		t.Fatal("Expected tgz to contain test2.txt but it didnt")
+	}
+}
+
 func TestAddingTwoFilesByPath(t *testing.T) {
 	tarFile := "./fixtures/twoFileByPath.tar.gz"
-	err, tgz := New(tarFile)
+	tgz, err := New(tarFile)
 
 	if err != nil {
 		t.Fatal(err)
@@ -151,7 +237,7 @@ func TestAddingTwoFilesByPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tgz.Finish()
+	tgz.Close()
 
 	tar, _ := os.Open(tgz.Path)
 	tarStats, _ := tar.Stat()
@@ -163,7 +249,7 @@ func TestAddingTwoFilesByPath(t *testing.T) {
 	}
 	tar.Close()
 
-	err, files := decompressAndListFiles(tgz.Path)
+	files, err := decompressAndListFiles(tgz.Path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +263,7 @@ func TestAddingTwoFilesByPath(t *testing.T) {
 
 func TestAddingMixedFiles(t *testing.T) {
 	tarFile := "./fixtures/twoMixedFiles.tar.gz"
-	err, tgz := New(tarFile)
+	tgz, err := New(tarFile)
 
 	if err != nil {
 		t.Fatal(err)
@@ -194,7 +280,7 @@ func TestAddingMixedFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tgz.Finish()
+	tgz.Close()
 
 	tar, _ := os.Open(tgz.Path)
 	tarStats, _ := tar.Stat()
@@ -206,7 +292,7 @@ func TestAddingMixedFiles(t *testing.T) {
 	}
 	tar.Close()
 
-	err, files := decompressAndListFiles(tgz.Path)
+	files, err := decompressAndListFiles(tgz.Path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,7 +306,7 @@ func TestAddingMixedFiles(t *testing.T) {
 
 func TestAddingFilesInSubdirs(t *testing.T) {
 	tarFile := "./fixtures/filesInSubdirs.tar.gz"
-	err, tgz := New(tarFile)
+	tgz, err := New(tarFile)
 
 	if err != nil {
 		t.Fatal(err)
@@ -244,7 +330,7 @@ func TestAddingFilesInSubdirs(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	tgz.Finish()
+	tgz.Close()
 
 	tar, _ := os.Open(tgz.Path)
 	tarStats, _ := tar.Stat()
@@ -256,7 +342,7 @@ func TestAddingFilesInSubdirs(t *testing.T) {
 	}
 	tar.Close()
 
-	err, outFiles := decompressAndListFiles(tgz.Path)
+	outFiles, err := decompressAndListFiles(tgz.Path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +355,7 @@ func TestAddingFilesInSubdirs(t *testing.T) {
 
 func TestWritingToAFinishedTgz(t *testing.T) {
 	tarFile := "./fixtures/filesInSubdirs.tar.gz"
-	err, tgz := New(tarFile)
+	tgz, err := New(tarFile)
 
 	if err != nil {
 		t.Fatal(err)
@@ -293,7 +379,7 @@ func TestWritingToAFinishedTgz(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	tgz.Finish()
+	tgz.Close()
 
 	tar, _ := os.Open(tgz.Path)
 	tarStats, _ := tar.Stat()
@@ -316,7 +402,7 @@ func TestWritingToAFinishedTgz(t *testing.T) {
 
 func TestWritingToExistingTar(t *testing.T) {
 	tarFile := "./fixtures/rewriteTo.tar.gz"
-	err, tgz := New(tarFile)
+	tgz, err := New(tarFile)
 
 	if err != nil {
 		t.Fatal(err)
@@ -333,7 +419,7 @@ func TestWritingToExistingTar(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tgz.Finish()
+	tgz.Close()
 
 	tar, _ := os.Open(tgz.Path)
 	tarStats, _ := tar.Stat()
@@ -344,7 +430,7 @@ func TestWritingToExistingTar(t *testing.T) {
 		t.Fatalf("tar is much larger than expected, should be < 2048 but is %d byes", tarStats.Size())
 	}
 
-	err, tgz = New(tarFile)
+	tgz, err = New(tarFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,7 +444,7 @@ func TestWritingToExistingTar(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tgz.Finish()
+	tgz.Close()
 	tar, _ = os.Open(tgz.Path)
 	tarStats, _ = tar.Stat()
 	if tarStats.Size() == 0 {
@@ -369,7 +455,7 @@ func TestWritingToExistingTar(t *testing.T) {
 	}
 	tar.Close()
 
-	err, files := decompressAndListFiles(tgz.Path)
+	files, err := decompressAndListFiles(tgz.Path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,14 +467,14 @@ func TestWritingToExistingTar(t *testing.T) {
 	}
 }
 
-func decompressAndListFiles(pathToTgz string) (error, map[string]string) {
+func decompressAndListFiles(pathToTgz string) (map[string]string, error) {
 	os.Mkdir("./fixtures/uncompressed", 0755)
 	defer os.RemoveAll("./fixtures/uncompressed")
 
 	cmd := exec.Command("tar", "-xf", pathToTgz, "-C", "./fixtures/uncompressed")
 	err := cmd.Run()
 	if err != nil {
-		return err, nil
+		return nil, err
 	}
 	ret := map[string]string{}
 
@@ -398,8 +484,8 @@ func decompressAndListFiles(pathToTgz string) (error, map[string]string) {
 	})
 
 	if err != nil {
-		return err, nil
+		return nil, err
 	}
 
-	return nil, ret
+	return ret, nil
 }


### PR DESCRIPTION
Allow adding files by buffer.

```
11:08 $ go test --coverprofile cover.out
PASS
coverage: 84.6% of statements
ok      github.com/philbrookes/go-tgz   0.057s
```
